### PR TITLE
linux-user: properly test for infinite timeout in poll

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -9770,7 +9770,7 @@ abi_long do_syscall(void *cpu_env, int num, abi_ulong arg1,
             {
                 struct timespec ts, *pts;
 
-                if (arg3 >= 0) {
+                if ((abi_long)arg3 >= 0) {
                     /* Convert ms to secs, ns */
                     ts.tv_sec = arg3 / 1000;
                     ts.tv_nsec = (arg3 % 1000) * 1000000LL;


### PR DESCRIPTION
After "linux-user: use target_ulong" the poll syscall was no longer
handling infinite timeout.

Signed-off-by: Andreas Schwab <schwab@suse.de>