### PR TITLE
linux-user: fill out task state in /proc/self/stat

### DIFF
--- a/linux-user/syscall.c
+++ b/linux-user/syscall.c
@@ -8062,6 +8062,9 @@ static int open_self_stat(CPUArchState *cpu_env, int fd)
             gchar *bin = g_strrstr(ts->bprm->argv[0], "/");
             bin = bin ? bin + 1 : ts->bprm->argv[0];
             g_string_printf(buf, "(%.15s) ", bin);
+        } else if (i == 2) {
+            /* task state */
+            g_string_assign(buf, "R "); /* we are running right now */
         } else if (i == 3) {
             /* ppid */
             g_string_printf(buf, FMT_pid " ", getppid());


### PR DESCRIPTION
Some programs want to match an actual task state character.


Reviewed-by: Laurent Vivier <laurent@vivier.eu>
Message-Id: <mvmedq2kxoe.fsf@suse.de>

(cherry picked from commit 25bb27c715f6ea7cd68561112cbfc1dba4ff46bd)