### PR TITLE
[openSUSE][RPM] spec: require virtiofsd, now that it is a sep package

### DIFF
--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -1588,6 +1588,7 @@ Summary:        Tools for QEMU
 Group:          System/Emulators/PC
 Requires(pre):  permissions
 Requires:       group(kvm)
+Requires:       virtiofsd
 Recommends:     multipath-tools
 Recommends:     qemu-block-curl
 %if 0%{?with_rbd}


### PR DESCRIPTION
Since version 8.0.0, virtiofsd is not part of QEMU sources any longer. We therefore have also moved it to a separate package. To retain compatibility and consistency of behavior, require such a package as an hard dependency.