### PR TITLE
 [openSUSE][RPM] Use --preserve-argv0 in qemu-linux-user

### DIFF
--- a/rpm/qemu-linux-user.spec
+++ b/rpm/qemu-linux-user.spec
@@ -315,7 +315,7 @@ unlink %{buildroot}%_datadir/qemu/trace-events-all
 install -d -m 755 %{buildroot}%_sbindir
 install -m 755 scripts/qemu-binfmt-conf.sh %{buildroot}%_sbindir
 install -d -m 755 %{buildroot}%{_prefix}/lib/binfmt.d/
-scripts/qemu-binfmt-conf.sh --systemd ALL --persistent yes --exportdir %{buildroot}%{_prefix}/lib/binfmt.d/
+scripts/qemu-binfmt-conf.sh --systemd ALL --persistent yes --preserve-argv0 yes --exportdir %{buildroot}%{_prefix}/lib/binfmt.d/
 
 %fdupes -s %{buildroot}
 


### PR DESCRIPTION
By default try to preserve argv[0].

Original report is boo#1197298, which also became relevant recently again in bsc#1212768.