### PR TITLE
[openSUSE][spec] Use discount instead of perl-Text-Markdown

### DIFF
--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -194,7 +194,7 @@ BuildRequires:  fdupes
 BuildRequires:  gcc-c++
 BuildRequires:  meson
 BuildRequires:  ninja >= 1.7
-BuildRequires:  perl-Text-Markdown
+BuildRequires:  discount
 BuildRequires:  python3-base >= 3.6
 BuildRequires:  python3-setuptools
 %if %{kvm_available}


### PR DESCRIPTION
perl-Text-Markdown is not always available (e.g., in SLE/Leap). Use discount instead, as the provider of the 'markdown' binary.