### PR TITLE
Normalize Hostname

### DIFF
--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -459,6 +459,8 @@ find . -iname ".git" -exec rm -rf {} +
 
 mkdir -p %blddir
 cd %blddir
+export USER=abuild
+export HOSTNAME=OBS # is used in roms/SLOF/Makefile.gen (boo#1084909)
 
 # We define a few general and common options and then we disable
 # pretty much everything. Afterwards, there is a section for each


### PR DESCRIPTION
Normalize `HOSTNAME`.

Without this path, the build machine host name
got embedded into `slof.bin`.

Also use a fixed `USER` value (in case someone builds outside of OBS/osc)

Together with
https://gitlab.com/qemu-project/SLOF/-/commit/08bc29fba8f2e660e454c9e93ab44b558d109498
and
commit 69a56ae695f3e14a90147299022301fe48a3359d it gave me bit-reproducible results.