### PR TITLE
Some spec file improvements

### DIFF
--- a/rpm/common.inc
+++ b/rpm/common.inc
@@ -12,10 +12,17 @@
 %define legacy_qemu_kvm 0
 %define force_fit_virtio_pxe_rom 1
 
+%define with_xen 0%{!?_without_xen:1}
+
 %if "%{?distribution}" == ""
 %define distro private-build
 %else
 %define distro %{distribution}
+%endif
+
+# Items to exclude in ALP-based products
+%if 0%{?suse_version} == 1600
+%define with_xen 0
 %endif
 
 %bcond_with system_membarrier

--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -1014,7 +1014,10 @@ necessary for having SPICE working for your VMs.
 Summary:        Minimum set of packages for having a functional QEMU
 Group:          System/Emulators/PC
 Requires:       qemu
+Requires:       qemu-block-curl
+Requires:       qemu-block-nfs
 Requires:       qemu-img
+Requires:       virtiofsd
 %if %{legacy_qemu_kvm}
 Requires:       qemu-kvm
 %endif

--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -115,7 +115,9 @@ BuildRequires:  cross-ppc64-gcc%gcc_version
 %endif
 %ifarch x86_64
 BuildRequires:  gcc-32bit
+%if %{with_xen}
 BuildRequires:  xen-devel >= 4.2
+%endif
 BuildRequires:  pkgconfig(libpmem)
 %endif
 %ifnarch %arm s390x
@@ -639,8 +641,10 @@ EXTRA_CFLAGS="$(echo %{optflags} | sed -E 's/-[A-Z]?_FORTIFY_SOURCE[=]?[0-9]*//g
 %ifarch x86_64
 	--enable-avx2 \
 	--enable-libpmem \
+%if %{with_xen}
 	--enable-xen \
 	--enable-xen-pci-passthrough \
+%endif
 %endif
 %ifnarch %arm s390x
 	--enable-numa \


### PR DESCRIPTION
- Make the qemu-headless file more useful, even in cases when recommended packages are disabled.
- Disable Xen support in ALP-based distributions