### PR TITLE
[openSUSE] rpm: fix virtiofsd dependency on 32 bit systems

### DIFF
--- a/rpm/common.inc
+++ b/rpm/common.inc
@@ -36,6 +36,12 @@
 %bcond_with canokey
 %endif
 
+%define has_virtiofsd 1
+# Upstream virtiofsd does not even build on 32 bit systems
+%ifarch %ix86 %arm
+%define has_virtiofsd 0
+%endif
+
 # non-x86 archs still seem to have some issues with Link Time Optimization
 %ifnarch %ix86 x86_64
 %define _lto_cflags %{nil}

--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -1027,7 +1027,9 @@ Requires:       qemu
 Requires:       qemu-block-curl
 Requires:       qemu-block-nfs
 Requires:       qemu-img
+%if %{has_virtiofsd}
 Requires:       virtiofsd
+%endif
 %if %{legacy_qemu_kvm}
 Requires:       qemu-kvm
 %endif
@@ -1631,8 +1633,7 @@ Requires(pre):  permissions
 Requires:       qemu-img
 Requires:       qemu-pr-helper
 Requires:       group(kvm)
-# Upstream virtiofsd does not even build on 32 bit systems...
-%ifnarch %ix86 %arm
+%if %{has_virtiofsd}
 Requires:       virtiofsd
 %endif
 Recommends:     multipath-tools


### PR DESCRIPTION
And make the switch more general, as we now have multiple instances of it.