### PR TITLE
[openSUSE][RPM]: Install the VGA module "more often" (bsc#1219164)

### DIFF
--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -1100,7 +1100,7 @@ necessary for having SPICE working for your VMs.
 %package audio-spice
 Summary:        Spice based audio support for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-ui-spice-core
+Requires:       qemu-ui-spice-core = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description audio-spice
@@ -1113,7 +1113,7 @@ This package contains a module for Spice based audio support for QEMU.
 %package chardev-spice
 Summary:        Spice vmc and port chardev support for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-ui-spice-core
+Requires:       qemu-ui-spice-core = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description chardev-spice
@@ -1127,8 +1127,8 @@ This package contains a module for Spice chardev support for QEMU.
 %package ui-spice-app
 Summary:        Spice UI support for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-chardev-spice
-Requires:       qemu-ui-spice-core
+Requires:       qemu-chardev-spice = %{version}-%{release}
+Requires:       qemu-ui-spice-core = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description ui-spice-app
@@ -1143,7 +1143,7 @@ Summary:        Core Spice support for QEMU
 Group:          System/Emulators/PC
 Requires:       qemu-ui-opengl
 # This next Requires is only since virt-manager expects audio support
-Requires:       qemu-audio-spice
+Requires:       qemu-audio-spice = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description ui-spice-core
@@ -1157,7 +1157,7 @@ This package contains a module with core Spice support for QEMU.
 %package hw-display-qxl
 Summary:        QXL display support for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-ui-spice-core
+Requires:       qemu-ui-spice-core = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description hw-display-qxl
@@ -1516,6 +1516,12 @@ This package contains a module for baum braille chardev support for QEMU.
 %package hw-display-virtio-gpu
 Summary:        Virtio GPU display support for QEMU
 Group:          System/Emulators/PC
+# Make sure that VGA is pretty much always there. Technically, this isn't
+# really necessary (and/or, should be dealt with in other places) but it
+# makes it easier to deal with strange situation where, e.g., GRUB is
+# configured to work only with a graphical terminal (see bsc#1219164),
+# and the hw-display-virtio-vga package is small enough, anyway.
+Requires:       qemu-hw-display-virtio-vga = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description hw-display-virtio-gpu
@@ -1529,7 +1535,7 @@ This package contains a module for Virtio GPU display support for QEMU.
 %package hw-display-virtio-gpu-pci
 Summary:        Virtio-gpu pci device for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-hw-display-virtio-gpu
+Requires:       qemu-hw-display-virtio-gpu = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description hw-display-virtio-gpu-pci
@@ -1558,7 +1564,7 @@ This package contains a module providing the virtio vga device for QEMU.
 %package hw-s390x-virtio-gpu-ccw
 Summary:        S390x virtio-gpu ccw device for QEMU
 Group:          System/Emulators/PC
-Requires:       qemu-hw-display-virtio-gpu
+Requires:       qemu-hw-display-virtio-gpu = %{version}-%{release}
 %{qemu_module_conflicts}
 
 %description hw-s390x-virtio-gpu-ccw


### PR DESCRIPTION
Depending on the VM configuration (both at the VM definition level and on the guest itself) a VGA console might be necessary, or weird lockup will occur. Since the VGA module package is smalle enough, add a dependency for it, from other display modules, to act as a workaround.

While there, make more explicit and precise the dependencies between all the various modules, by specifying that they should all have the same version and release.

References: bsc#1219164