### PR TITLE
[openSUSE][RPM] Fix handling of qemu-kvm legacy package for RISCV

### DIFF
--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -960,6 +960,9 @@ ln -s qemu-system-ppc64/ %{buildroot}%_bindir/qemu-kvm
 %ifarch s390x
 ln -s qemu-system-s390x/ %{buildroot}%_bindir/qemu-kvm
 %endif
+%ifarch riscv64
+ln -s qemu-system-riscv64 %{buildroot}%_bindir/qemu-kvm
+%endif
 
 %if %{kvm_available}
 install -D -m 0644 %{rpmfilesdir}/80-kvm.rules %{buildroot}/usr/lib/udev/rules.d/80-kvm.rules


### PR DESCRIPTION
Create the (legacy) qemu-kvm link for RISCV as well.

Note that the qemu-system-riscv64 binary, to which the symlink should point, is in the qemu-extra package. However, if we are on RISCV, qemu-extra is an hard dependency of qemu. Therefore, it's fine to ship the link and also set the Provides: and Obsoletes: tag in the qemu package itself. It'd be more correct to do that in the qemu-extra package, of course, but this would complicate the spec file and it's not worth it, considering this is all legacy and should very well go away soon.

Fixes: 8ee1ae7ee5919b72a95bc05cbc04ad7b1da557ad