### PR TITLE
[openSUSE][RPM] factor common definitions between qemu and qemu-linux-user spec files

### DIFF
--- a/rpm/common.inc
+++ b/rpm/common.inc
@@ -65,6 +65,34 @@
 %define _lto_cflags %{nil}
 %endif
 
+%ifarch aarch64
+%define qemu_arch aarch64
+%endif
+%ifarch %arm
+%define qemu_arch arm
+%endif
+%ifarch %ix86
+%define qemu_arch i386
+%endif
+%ifarch ppc64
+%define qemu_arch ppc64
+%endif
+%ifarch ppc
+%define qemu_arch ppc
+%endif
+%ifarch ppc64le
+%define qemu_arch ppc64le
+%endif
+%ifarch riscv64
+%define qemu_arch riscv64
+%endif
+%ifarch s390x
+%define qemu_arch s390x
+%endif
+%ifarch x86_64
+%define qemu_arch x86_64
+%endif
+
 %define generic_qemu_description \
 QEMU provides full machine emulation and cross architecture usage. It closely\
 integrates with KVM and Xen virtualization, allowing for excellent performance.\

--- a/rpm/qemu-linux-user.spec
+++ b/rpm/qemu-linux-user.spec
@@ -343,35 +343,8 @@ scripts/qemu-binfmt-conf.sh --systemd ALL --persistent yes --preserve-argv0 yes 
 %check
 cd %blddir
 
-%ifarch %ix86
-%define qemu_arch i386
-%endif
-%ifarch x86_64
-%define qemu_arch x86_64
-%endif
-%ifarch %arm
-%define qemu_arch arm
-%endif
-%ifarch aarch64
-%define qemu_arch aarch64
-%endif
-%ifarch ppc
-%define qemu_arch ppc
-%endif
-%ifarch ppc64
-%define qemu_arch ppc64
-%endif
-%ifarch ppc64le
-%define qemu_arch ppc64le
-%endif
-%ifarch s390x
-%define qemu_arch s390x
-%endif
-
-%ifarch %ix86 x86_64 %arm aarch64 ppc ppc64 ppc64le s390x
-%ifnarch %arm
+%ifarch aarch64 %ix86 ppc ppc64 ppc64le riscv64 s390x x86_64
 %{qemu_arch}-linux-user/qemu-%{qemu_arch} %_bindir/ls > /dev/null
-%endif
 %endif
 
 %make_build check-softfloat

--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -939,29 +939,12 @@ rst2html --exit-status=2 %{buildroot}%_docdir/qemu-x86/supported.txt %{buildroot
 %endif
 # End of "if legacy_qemu_kvm"
 %endif
-%ifarch %ix86
-ln -s qemu-system-i386 %{buildroot}%_bindir/qemu-kvm
+
+%ifarch aarch64 %arm %ix86 ppc ppc64 ppc64le riscv64 s390x x86_64
+%ifarch ppc64le
+%define qemu_arch ppc64
 %endif
-%ifarch x86_64
-ln -s qemu-system-x86_64 %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch %arm
-ln -s qemu-system-arm %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch aarch64
-ln -s qemu-system-aarch64 %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch ppc
-ln -s qemu-system-ppc %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch ppc64 ppc64le
-ln -s qemu-system-ppc64/ %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch s390x
-ln -s qemu-system-s390x/ %{buildroot}%_bindir/qemu-kvm
-%endif
-%ifarch riscv64
-ln -s qemu-system-riscv64 %{buildroot}%_bindir/qemu-kvm
+ln -s qemu-system-%{qemu_arch} %{buildroot}%_bindir/qemu-kvm
 %endif
 
 %if %{kvm_available}


### PR DESCRIPTION

Simplify both the spec files, by factoring common definitions.

While there, switch the Obsoletes of qemu-kvm to "< %{version}-%{release}" as this seems to be a better solution.