### PR TITLE
[openSUSE] Add packaging for documentation in info format

### DIFF
--- a/docs/meson.build
+++ b/docs/meson.build
@@ -97,6 +97,28 @@ if build_docs
   alias_target('sphinxdocs', sphinxdocs)
   alias_target('html', sphinxdocs)
   alias_target('man', sphinxmans)
+
+  # Add a target to build and install a Texinfo version of the QEMU
+  # manual, if 'makeinfo' is available.
+  makeinfo = find_program(['texi2any', 'makeinfo'])
+  if makeinfo.found()
+    sphinxtexi = custom_target(
+      'qemu.texi',
+      output: ['qemu.texi', 'sphinxtexi.stamp'],
+      depfile: 'sphinxtexi.d',
+      command: [SPHINX_ARGS, '-Ddepfile=@DEPFILE@',
+               '-Ddepfile_stamp=@OUTPUT1@', '-b', 'texinfo',
+               '-d', private_dir, input_dir, meson.current_build_dir()])
+    sphinxinfo = custom_target(
+      'qemu.info',
+      input: sphinxtexi,
+      output: 'qemu.info',
+      install: true,
+      install_dir: get_option('infodir'),
+      command: [makeinfo, '--no-split', '--output=@OUTPUT@', '@INPUT0@'])
+    alias_target('texi', sphinxtexi)
+    alias_target('info', sphinxinfo)
+  endif
 endif
 
 test('QAPI firmware.json regression tests', qapi_gen,

--- a/rpm/qemu.spec
+++ b/rpm/qemu.spec
@@ -166,6 +166,7 @@ BuildRequires:  python3-sphinx_rtd_theme
 BuildRequires:  python311-Sphinx
 BuildRequires:  python311-base
 %endif
+BuildRequires:  texinfo
 BuildRequires:  Mesa-devel
 BuildRequires:  bison
 BuildRequires:  brlapi-devel
@@ -1965,5 +1966,20 @@ Suggests:       qemu
 %{generic_qemu_description}
 
 This package contains user and developer documentation for QEMU.
+
+%package info
+Summary:        Documentation for QEMU in the info-pages format
+Group:          System/Emulators/PC
+BuildArch:      noarch
+Suggests:       qemu
+
+%files info
+%{_infodir}/*
+
+%description info
+%{generic_qemu_description}
+
+This package contains user and developer documentation for QEMU in
+the GNU info-pages format.
 
 %changelog


### PR DESCRIPTION
Add packaging for documentation in the info format.

The original source of the patch adding the info target is Guix and was proposed to upstream
in:
https://lists.gnu.org/archive/html/qemu-devel/2024-03/msg04257.html