### PR TITLE
qemu-linux-user: drop pcre

### DIFF
--- a/rpm/qemu-linux-user.spec
+++ b/rpm/qemu-linux-user.spec
@@ -38,7 +38,7 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildRequires:  bison
 BuildRequires:  glib2-devel-static >= 2.56
 BuildRequires:  glibc-devel-static
-BuildRequires:  (pcre-devel-static if glib2-devel-static < 2.73 else pcre2-devel-static)
+BuildRequires:  pcre2-devel-static
 # passing filelist check for /usr/lib/binfmt.d
 BuildRequires:  systemd
 BuildRequires:  zlib-devel-static


### PR DESCRIPTION
qemu-linux-user: drop conditional requirement on pcre, all glib2 versions are recent enough to use pcre2

See https://build.opensuse.org/request/show/1266674
See https://lists.opensuse.org/archives/list/factory@lists.opensuse.org/thread/BK3SPPFOM3LI6K5PTXPKZMKMIUIPOEXS/